### PR TITLE
allow to skip parameter to get

### DIFF
--- a/specs/Endpoint/abstract-wp-endpoint.spec.php
+++ b/specs/Endpoint/abstract-wp-endpoint.spec.php
@@ -19,6 +19,21 @@ describe(AbstractWpEndpoint::class, function () {
             $data = $endpoint->get(55);
             expect($data)->to->equal(['foo' => 'bar']);
         });
+
+        it('should make a GET request without any ID', function () {
+            $client = $this->getProphet()->prophesize(WpClient::class);
+
+            $request = new Request('GET', '/foo');
+            $response = new \GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], '{"foo": "bar"}');
+
+            $client->send($request)->willReturn($response)->shouldBeCalled();
+
+            $endpoint = new FakeEndpoint($client->reveal());
+
+            $data = $endpoint->get();
+            expect($data)->to->equal(['foo' => 'bar']);
+        });
+
     });
 
     describe('save()', function () {

--- a/src/Endpoint/AbstractWpEndpoint.php
+++ b/src/Endpoint/AbstractWpEndpoint.php
@@ -34,7 +34,7 @@ abstract class AbstractWpEndpoint
      */
     public function get($id = null)
     {
-        $request = new Request('GET', $this->getEndpoint()   . (is_null($id)?'': '/' . $id) );
+        $request = new Request('GET', $this->getEndpoint()   . (is_null($id)?'': '/' . $id));
         $response = $this->client->send($request);
 
         if ($response->hasHeader('Content-Type')

--- a/src/Endpoint/AbstractWpEndpoint.php
+++ b/src/Endpoint/AbstractWpEndpoint.php
@@ -32,9 +32,9 @@ abstract class AbstractWpEndpoint
      * @param int $id
      * @return array
      */
-    public function get($id)
+    public function get($id = null)
     {
-        $request = new Request('GET', $this->getEndpoint()   . '/' . $id);
+        $request = new Request('GET', $this->getEndpoint()   . (is_null($id)?'': '/' . $id) );
         $response = $this->client->send($request);
 
         if ($response->hasHeader('Content-Type')


### PR DESCRIPTION
This allows to get a list of all the categories or tags as defined [here](http://v2.wp-api.org/reference/tags/) for example