### PR TITLE
endpoint GET able to pass parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,9 @@ $user = $client->users()->get(2);
 
 print_r($user);
 ```
+
+## Testing
+```bash
+composer install
+vendor/bin/peridot
+```

--- a/specs/Endpoint/abstract-wp-endpoint.spec.php
+++ b/specs/Endpoint/abstract-wp-endpoint.spec.php
@@ -34,6 +34,20 @@ describe(AbstractWpEndpoint::class, function () {
             expect($data)->to->equal(['foo' => 'bar']);
         });
 
+        it('should make a GET request with parameters', function () {
+            $client = $this->getProphet()->prophesize(WpClient::class);
+
+            $request = new Request('GET', '/foo?bar=baz');
+            $response = new \GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], '{"foo": "bar"}');
+
+            $client->send($request)->willReturn($response)->shouldBeCalled();
+
+            $endpoint = new FakeEndpoint($client->reveal());
+
+            $data = $endpoint->get(null, ['bar'=>'baz']);
+            expect($data)->to->equal(['foo' => 'bar']);
+        });
+
     });
 
     describe('save()', function () {

--- a/src/Endpoint/AbstractWpEndpoint.php
+++ b/src/Endpoint/AbstractWpEndpoint.php
@@ -30,11 +30,17 @@ abstract class AbstractWpEndpoint
 
     /**
      * @param int $id
+     * @param array $params - parameters that can be passed to GET
+     *        e.g. for tags: https://developer.wordpress.org/rest-api/reference/tags/#arguments
      * @return array
      */
-    public function get($id = null)
+    public function get($id = null, array $params = null)
     {
-        $request = new Request('GET', $this->getEndpoint()   . (is_null($id)?'': '/' . $id));
+        $uri = $this->getEndpoint();
+        $uri .= (is_null($id)?'': '/' . $id);
+        $uri .= (is_null($params)?'': '?' . http_build_query($params));
+
+        $request = new Request('GET', $uri);
         $response = $this->client->send($request);
 
         if ($response->hasHeader('Content-Type')


### PR DESCRIPTION
Added `params` field to `get` function of abstract endpoint in order to be able to pass GET parameters