### PR TITLE
Coaches -> Sportshub

### DIFF
--- a/src/Endpoint/SchoolUsers.php
+++ b/src/Endpoint/SchoolUsers.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Vnn\WpApiClient\Endpoint;
+
+/**
+ * Class SchoolUsers
+ * @package Vnn\WpApiClient\Endpoint
+ */
+class SchoolUsers extends AbstractWpEndpoint
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getEndpoint()
+    {
+        return '/wp-json/vnn/v1/school/user';
+    }
+}

--- a/src/WpClient.php
+++ b/src/WpClient.php
@@ -18,6 +18,7 @@ use Vnn\WpApiClient\Http\ClientInterface;
  * @method Endpoint\Posts posts()
  * @method Endpoint\PostStatuses postStatuses()
  * @method Endpoint\PostTypes postTypes()
+ * @method Endpoint\SchoolUsers schoolUsers()
  * @method Endpoint\Tags tags()
  * @method Endpoint\Users users()
  */
@@ -48,9 +49,17 @@ class WpClient
      * @param ClientInterface $httpClient
      * @param string $wordpressUrl
      */
-    public function __construct(ClientInterface $httpClient, $wordpressUrl)
+    public function __construct(ClientInterface $httpClient, $wordpressUrl = '')
     {
         $this->httpClient = $httpClient;
+        $this->wordpressUrl = $wordpressUrl;
+    }
+
+    /**
+     * @param $wordpressUrl
+     */
+    public function setWordpressUrl($wordpressUrl)
+    {
         $this->wordpressUrl = $wordpressUrl;
     }
 


### PR DESCRIPTION
This PR: 

1. Creates a `setWordpressUrl` function, so that we can set the url outside of the constructor (this was so we could register the classes in the API container without needing a dynamic wordpress url)

2. Creates a `SchoolUsers` endpoint that will return all the Wordpress users for a specific school blog. 

Dependent on https://github.com/varsitynewsnetwork/sportshub/pull/596