### PR TITLE
RuntimeException class not found when used in try/catch block

### DIFF
--- a/src/WpClient.php
+++ b/src/WpClient.php
@@ -4,6 +4,7 @@ namespace Vnn\WpApiClient;
 
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
 use Vnn\WpApiClient\Auth\AuthInterface;
 use Vnn\WpApiClient\Endpoint;
 use Vnn\WpApiClient\Http\ClientInterface;


### PR DESCRIPTION
I was getting the following error:

FatalThrowableError in WpClient.php line 95: Class 'Vnn\WpApiClient\RuntimeException' not found