### PR TITLE
Adding method that returns PSR-7 response object

### DIFF
--- a/specs/Endpoint/abstract-wp-endpoint.spec.php
+++ b/specs/Endpoint/abstract-wp-endpoint.spec.php
@@ -50,6 +50,51 @@ describe(AbstractWpEndpoint::class, function () {
 
     });
 
+    describe('getResponse()', function () {
+        it('should make a GET request to the endpoint URL', function () {
+            $client = $this->getProphet()->prophesize(WpClient::class);
+
+            $request = new Request('GET', '/foo/55');
+            $response = new \GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], '{"foo": "bar"}');
+
+            $client->send($request)->willReturn($response)->shouldBeCalled();
+
+            $endpoint = new FakeEndpoint($client->reveal());
+
+            $data = $endpoint->getResponse(55);
+            expect($data)->to->equal($response);
+        });
+
+        it('should make a GET request without any ID', function () {
+            $client = $this->getProphet()->prophesize(WpClient::class);
+
+            $request = new Request('GET', '/foo');
+            $response = new \GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], '{"foo": "bar"}');
+
+            $client->send($request)->willReturn($response)->shouldBeCalled();
+
+            $endpoint = new FakeEndpoint($client->reveal());
+
+            $data = $endpoint->getResponse();
+            expect($data)->to->equal($response);
+        });
+
+        it('should make a GET request with parameters', function () {
+            $client = $this->getProphet()->prophesize(WpClient::class);
+
+            $request = new Request('GET', '/foo?bar=baz');
+            $response = new \GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], '{"foo": "bar"}');
+
+            $client->send($request)->willReturn($response)->shouldBeCalled();
+
+            $endpoint = new FakeEndpoint($client->reveal());
+
+            $data = $endpoint->getResponse(null, ['bar'=>'baz']);
+            expect($data)->to->equal($response);
+        });
+
+    });
+
     describe('save()', function () {
         it('should make a POST request to the endpoint URL', function () {
             $client = $this->getProphet()->prophesize(WpClient::class);

--- a/src/Endpoint/AbstractWpEndpoint.php
+++ b/src/Endpoint/AbstractWpEndpoint.php
@@ -52,6 +52,29 @@ abstract class AbstractWpEndpoint
     }
 
     /**
+     * @param int $id
+     * @param array $params - parameters that can be passed to GET
+     *        e.g. for tags: https://developer.wordpress.org/rest-api/reference/tags/#arguments
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function getResponse($id = null, array $params = null)
+    {
+        $uri = $this->getEndpoint();
+        $uri .= (is_null($id)?'': '/' . $id);
+        $uri .= (is_null($params)?'': '?' . http_build_query($params));
+
+        $request = new Request('GET', $uri);
+        $response = $this->client->send($request);
+
+        if ($response->hasHeader('Content-Type')
+            && substr($response->getHeader('Content-Type')[0], 0, 16) === 'application/json') {
+            return $response;
+        }
+
+        throw new RuntimeException('Unexpected response');
+    }
+
+    /**
      * @param array $data
      * @return array
      */


### PR DESCRIPTION
Close # 13

Adding `getResponse` method that returns a response object that implements` ResponseInterface` from PSR-7

I have not modified the `get` method of AbstractWpEndpoint at: https://github.com/varsitynewsnetwork/wordpress-rest-api-client/blob/master/src/Endpoint/AbstractWpEndpoint.php#L46-L49 with the intention of preserving the compatibility as described by @te-online.