### PR TITLE
Return responses as a ResultSet object

### DIFF
--- a/specs/Endpoint/abstract-wp-endpoint.spec.php
+++ b/specs/Endpoint/abstract-wp-endpoint.spec.php
@@ -75,7 +75,7 @@ describe(AbstractWpEndpoint::class, function () {
             $client = $this->getProphet()->prophesize(WpClient::class);
 
             $request = new Request('GET', '/foo/55');
-            $response = new \GuzzleHttp\Psr7\Response(200, [], '{"foo": "bar"}');
+            $response = new \GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], '{"foo": "bar"}');
 
             $client->send($request)->willReturn($response)->shouldBeCalled();
 

--- a/src/Endpoint/AbstractWpEndpoint.php
+++ b/src/Endpoint/AbstractWpEndpoint.php
@@ -42,10 +42,10 @@ abstract class AbstractWpEndpoint
 
         $request = new Request('GET', $uri);
         $response = $this->client->send($request);
+        $results = new ResultSet($request, $response);
 
-        if ($response->hasHeader('Content-Type')
-            && substr($response->getHeader('Content-Type')[0], 0, 16) === 'application/json') {
-            return json_decode($response->getBody()->getContents(), true);
+        if (count($results)) {
+            return $results;
         }
 
         throw new RuntimeException('Unexpected response');
@@ -66,10 +66,10 @@ abstract class AbstractWpEndpoint
 
         $request = new Request('POST', $url, ['Content-Type' => 'application/json'], json_encode($data));
         $response = $this->client->send($request);
+        $results = new ResultSet($request, $response);
 
-        if ($response->hasHeader('Content-Type')
-            && substr($response->getHeader('Content-Type')[0], 0, 16) === 'application/json') {
-            return json_decode($response->getBody()->getContents(), true);
+        if (count($results)) {
+            return $results;
         }
 
         throw new RuntimeException('Unexpected response');

--- a/src/Endpoint/ResultSet.php
+++ b/src/Endpoint/ResultSet.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Vnn\WpApiClient\Endpoint;
+
+use ArrayObject;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Class ResultSet
+ * @package Vnn\WpApiClient\Endpoint
+ */
+class ResultSet extends ArrayObject
+{
+    /**
+     * @var int
+     */
+    public $total = 0;
+
+    /**
+     * @var int
+     */
+    public $totalPages = 0;
+
+    /**
+     * @var Psr\Http\Message\RequestInterface
+     */
+    public $request;
+
+    /**
+     * @param RequestInterface $request
+     * @param ResponseInterface &$response
+     * @return ResultSet
+     */
+    public function __construct(RequestInterface $request, ResponseInterface &$response)
+    {
+        $this->request = $request;
+
+        if ($this->validateResponse($response)) {
+            parent::__construct(json_decode($response->getBody()->getContents(), true));
+            $this->setHeaders($response);
+        }
+    }
+
+    private function setHeaders(ResponseInterface &$response)
+    {
+        if ($response->hasHeader('X-WP-Total')) {
+            $this->total = (int) $response->getHeader('X-WP-Total')[0];
+        }
+
+        if ($response->hasHeader('X-WP-TotalPages')) {
+            $this->totalPages = (int) $response->getHeader('X-WP-TotalPages')[0];
+        }
+    }
+
+    private function validateResponse(ResponseInterface &$response)
+    {
+        return (
+            $response->hasHeader('Content-Type') &&
+            substr($response->getHeader('Content-Type')[0], 0, 16) === 'application/json');
+    }
+}


### PR DESCRIPTION
By returning a ResultSet object, which extends ArrayObject, we are able to return other valuable information about the result without breaking array-like functionality. The additional data attached is the WP-Total and WP-TotalPages headers (addresses #15) as well as the original request.

ArrayObject's should behave exactly the same as the response from `json_decode()`, with the exception of direct type checking. Although I don't expect type checking the returned data to be common, this could be considered a breaking change because of that.

The tests were modified since the response is no longer just an array. This could also have been rewritten by casting the `ResultSet` such as:

    expect((array) $data)->to->equal(['foo' => 'bar']);

Feel free to suggest naming change or coding style changes if you see them.