### PR TITLE
Possibility to use wordpress public API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,6 @@
 {
   "name": "vnn/wordpress-rest-api-client",
-  "autoload": {
-    "psr-4": {
-      "Vnn\\WpApiClient\\": "src/"
-    }
-  },
+  "license": "MIT",
   "require": {
     "php": ">= 5.6, <= 8.0",
     "psr/http-message": "^1.0"
@@ -18,5 +14,10 @@
   },
   "suggest": {
     "guzzlehttp/guzzle": "^6.2"
+  },
+  "autoload": {
+    "psr-4": {
+      "Vnn\\WpApiClient\\": "src/"
+    }
   }
 }

--- a/specs/Endpoint/abstract-wp-endpoint.spec.php
+++ b/specs/Endpoint/abstract-wp-endpoint.spec.php
@@ -75,7 +75,7 @@ describe(AbstractWpEndpoint::class, function () {
             $client = $this->getProphet()->prophesize(WpClient::class);
 
             $request = new Request('GET', '/foo/55');
-            $response = new \GuzzleHttp\Psr7\Response(200, [], '{"foo": "bar"}');
+            $response = new \GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/json'], '{"foo": "bar"}');
 
             $client->send($request)->willReturn($response)->shouldBeCalled();
 

--- a/src/Endpoint/AbstractWpEndpoint.php
+++ b/src/Endpoint/AbstractWpEndpoint.php
@@ -18,12 +18,18 @@ abstract class AbstractWpEndpoint
     private $client;
 
     /**
+     * @var bool
+     */
+    private $public;
+
+    /**
      * Users constructor.
      * @param WpClient $client
      */
     public function __construct(WpClient $client)
     {
         $this->client = $client;
+        $this->public = $client->isPublic();
     }
 
     abstract protected function getEndpoint();
@@ -40,15 +46,7 @@ abstract class AbstractWpEndpoint
         $uri .= (is_null($id)?'': '/' . $id);
         $uri .= (is_null($params)?'': '?' . http_build_query($params));
 
-        $request = new Request('GET', $uri);
-        $response = $this->client->send($request);
-        $results = new ResultSet($request, $response);
-
-        if (count($results)) {
-            return $results;
-        }
-
-        throw new RuntimeException('Unexpected response');
+        return $this->sendRequest(new Request('GET', $uri));
     }
 
     /**
@@ -64,12 +62,19 @@ abstract class AbstractWpEndpoint
             unset($data['id']);
         }
 
-        $request = new Request('POST', $url, ['Content-Type' => 'application/json'], json_encode($data));
+        return $this->sendRequest(new Request('POST', $url, ['Content-Type' => 'application/json'], json_encode($data)));
+    }
+
+    /**
+     * @param \GuzzleHttp\Psr7\Request $request
+     * @return array
+     */
+    public function sendRequest(Request $request) {
         $response = $this->client->send($request);
         $results = new ResultSet($request, $response);
 
-        if (count($results)) {
-            return $results;
+       if (count($results)) {
+         return $results;
         }
 
         throw new RuntimeException('Unexpected response');

--- a/src/Endpoint/AbstractWpEndpoint.php
+++ b/src/Endpoint/AbstractWpEndpoint.php
@@ -42,10 +42,10 @@ abstract class AbstractWpEndpoint
 
         $request = new Request('GET', $uri);
         $response = $this->client->send($request);
+        $results = new ResultSet($request, $response);
 
-        if ($response->hasHeader('Content-Type')
-            && substr($response->getHeader('Content-Type')[0], 0, 16) === 'application/json') {
-            return json_decode($response->getBody()->getContents(), true);
+        if (count($results)) {
+            return $results;
         }
 
         throw new RuntimeException('Unexpected response');
@@ -66,10 +66,10 @@ abstract class AbstractWpEndpoint
 
         $request = new Request('POST', $url, ['Content-Type' => 'application/json'], json_encode($data));
         $response = $this->client->send($request);
+        $results = new ResultSet($request, $response);
 
-        if ($response->hasHeader('Content-Type')
-            && substr($response->getHeader('Content-Type')[0], 0, 16) === 'application/json') {
-            return json_decode($response->getBody()->getContents(), true);
+        if (count($results)) {
+            return $results;
         }
 
         throw new RuntimeException('Unexpected response');

--- a/src/Endpoint/Categories.php
+++ b/src/Endpoint/Categories.php
@@ -13,6 +13,6 @@ class Categories extends AbstractWpEndpoint
      */
     protected function getEndpoint()
     {
-        return '/wp-json/wp/v2/categories';
+        return '/categories';
     }
 }

--- a/src/Endpoint/Comments.php
+++ b/src/Endpoint/Comments.php
@@ -13,6 +13,6 @@ class Comments extends AbstractWpEndpoint
      */
     protected function getEndpoint()
     {
-        return '/wp-json/wp/v2/comments';
+        return '/comments';
     }
 }

--- a/src/Endpoint/Media.php
+++ b/src/Endpoint/Media.php
@@ -13,6 +13,6 @@ class Media extends AbstractWpEndpoint
      */
     protected function getEndpoint()
     {
-        return '/wp-json/wp/v2/media';
+        return '/media';
     }
 }

--- a/src/Endpoint/Pages.php
+++ b/src/Endpoint/Pages.php
@@ -13,6 +13,6 @@ class Pages extends AbstractWpEndpoint
      */
     protected function getEndpoint()
     {
-        return '/wp-json/wp/v2/pages';
+        return '/pages';
     }
 }

--- a/src/Endpoint/PostStatuses.php
+++ b/src/Endpoint/PostStatuses.php
@@ -13,6 +13,6 @@ class PostStatuses extends AbstractWpEndpoint
      */
     protected function getEndpoint()
     {
-        return '/wp-json/wp/v2/statuses';
+        return '/statuses';
     }
 }

--- a/src/Endpoint/PostTypes.php
+++ b/src/Endpoint/PostTypes.php
@@ -13,6 +13,6 @@ class PostTypes extends AbstractWpEndpoint
      */
     protected function getEndpoint()
     {
-        return '/wp-json/wp/v2/types';
+        return '/types';
     }
 }

--- a/src/Endpoint/Posts.php
+++ b/src/Endpoint/Posts.php
@@ -13,6 +13,6 @@ class Posts extends AbstractWpEndpoint
      */
     protected function getEndpoint()
     {
-        return '/wp-json/wp/v2/posts';
+        return '/posts';
     }
 }

--- a/src/Endpoint/ResultSet.php
+++ b/src/Endpoint/ResultSet.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Vnn\WpApiClient\Endpoint;
+
+use ArrayObject;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Class ResultSet
+ * @package Vnn\WpApiClient\Endpoint
+ */
+class ResultSet extends ArrayObject
+{
+    /**
+     * @var int
+     */
+    public $total = 0;
+
+    /**
+     * @var int
+     */
+    public $totalPages = 0;
+
+    /**
+     * @var Psr\Http\Message\RequestInterface
+     */
+    public $request;
+
+    /**
+     * @param RequestInterface $request
+     * @param ResponseInterface &$response
+     * @return ResultSet
+     */
+    public function __construct(RequestInterface $request, ResponseInterface &$response)
+    {
+        $this->request = $request;
+
+        if ($this->validateResponse($response)) {
+            parent::__construct(json_decode($response->getBody()->getContents(), true));
+            $this->setHeaders($response);
+        }
+    }
+
+    private function setHeaders(ResponseInterface &$response)
+    {
+        if ($response->hasHeader('X-WP-Total')) {
+            $this->total = (int) $response->getHeader('X-WP-Total')[0];
+        }
+
+        if ($response->hasHeader('X-WP-TotalPages')) {
+            $this->totalPages = (int) $response->getHeader('X-WP-TotalPages')[0];
+        }
+    }
+
+    private function validateResponse(ResponseInterface &$response)
+    {
+        return (
+            $response->hasHeader('Content-Type') &&
+            substr($response->getHeader('Content-Type')[0], 0, 16) === 'application/json');
+    }
+}

--- a/src/Endpoint/ResultSet.php
+++ b/src/Endpoint/ResultSet.php
@@ -23,7 +23,7 @@ class ResultSet extends ArrayObject
     public $totalPages = 0;
 
     /**
-     * @var Psr\Http\Message\RequestInterface
+     * @var \Psr\Http\Message\RequestInterface
      */
     public $request;
 

--- a/src/Endpoint/Tags.php
+++ b/src/Endpoint/Tags.php
@@ -13,6 +13,6 @@ class Tags extends AbstractWpEndpoint
      */
     protected function getEndpoint()
     {
-        return '/wp-json/wp/v2/tags';
+        return '/tags';
     }
 }

--- a/src/Endpoint/Users.php
+++ b/src/Endpoint/Users.php
@@ -13,6 +13,6 @@ class Users extends AbstractWpEndpoint
      */
     protected function getEndpoint()
     {
-        return '/wp-json/wp/v2/users';
+        return '/users';
     }
 }


### PR DESCRIPTION
This PR includes changes posted by @andyvanee in the #16 and add possibility to use wordpress.com public API.
Example endpoint for posts:
"https://public-api.wordpress.com/wp/v2/sites/yoursite.wordpress.com/posts"