### PR TITLE
[Feature] Introducing Subendpoints

### DIFF
--- a/src/Endpoint/AbstractWpSubEndpoint.php
+++ b/src/Endpoint/AbstractWpSubEndpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Vnn\WpApiClient\Endpoint;
+
+/**
+ * Class AbstractWpSubEndpoint.
+ * Is the base class for endpoints that "have" a parent entity, e.g. post revisions.
+ * The setParent() method must be called before the get() method.
+ *
+ * Example:
+ * $client->postRevisions()->setParent(45)->get();
+ *
+ * @package Vnn\WpApiClient\Endpoint
+ */
+abstract class AbstractWpSubEndpoint extends AbstractWpEndpoint
+{
+    /**
+     * The ID of the parent entity.
+     * @var int
+     */
+    private $parentId = null;
+
+    /**
+     * Set the ID of the parent entity.
+     * @param int $parent
+     * @return AbstractWpEndpoint
+     */
+    public function setParent($parent)
+    {
+        $this->parentId = $parent;
+        return $this;
+    }
+
+    /**
+     * Builds the actual endpoint URL using the provided parent ID and the endpoint pattern.
+     * @param string $pattern
+     * @return string
+     * @throws \LogicException
+     */
+    protected function buildEndpoint($pattern)
+    {
+        if ($this->parentId === NULL) {
+            throw new \LogicException(static::class . '::setParent() not called!', 1539454211);
+        }
+        return sprintf($pattern, $this->parentId);
+    }
+}

--- a/src/Endpoint/PostRevisions.php
+++ b/src/Endpoint/PostRevisions.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Vnn\WpApiClient\Endpoint;
+
+/**
+ * Class PostRevisions
+ * @package Vnn\WpApiClient\Endpoint
+ */
+class PostRevisions extends AbstractWpSubEndpoint
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getEndpoint()
+    {
+        return $this->buildEndpoint('/wp-json/wp/v2/posts/%d/revisions');
+    }
+}

--- a/src/WpClient.php
+++ b/src/WpClient.php
@@ -22,6 +22,7 @@ use Vnn\WpApiClient\Http\ClientInterface;
  * @method Endpoint\PostTypes postTypes()
  * @method Endpoint\Tags tags()
  * @method Endpoint\Users users()
+ * @method Endpoint\PostRevisions postRevisions()
  */
 class WpClient
 {


### PR DESCRIPTION
Some WordPress API endpoints (e.g. [post revisions](https://developer.wordpress.org/rest-api/reference/post-revisions/)) must use a `<parent>` identifier, i.e. they always belong to another parent entity.
The new `AbstractWpSubEndpoint` makes this simple by offering the possibility to set the parent entity.

Also contains a new endpoint class, `PostRevisions`.

Example:
```
$client->postRevisions()->setParent(45)->get();
```