### PR TITLE
[Feature] Multiple namespaces to look for endpoints

### DIFF
--- a/src/WpClient.php
+++ b/src/WpClient.php
@@ -46,6 +46,18 @@ class WpClient
     private $endPoints = [];
 
     /**
+     * An array of namespaces that are searched for the requested endpoint.
+     * By default it contains the default namespace only.
+     * Additional namespaces can be added using the method addEndpointNamespace().
+     * Newly added namespaces are always prepended, thus will have priority over already existing namespaces.
+     * This also means that the default namespace has the lowest priority.
+     * @var array
+     */
+    private $endpointNamespaces = [
+        'Vnn\WpApiClient\Endpoint\\',
+    ];
+
+    /**
      * WpClient constructor.
      * @param ClientInterface $httpClient
      * @param string $wordpressUrl
@@ -80,10 +92,13 @@ class WpClient
     public function __call($endpoint, array $args)
     {
         if (!isset($this->endPoints[$endpoint])) {
-            $class = 'Vnn\WpApiClient\Endpoint\\' . ucfirst($endpoint);
-            if (class_exists($class)) {
-                $this->endPoints[$endpoint] = new $class($this);
-            } else {
+            foreach($this->endpointNamespaces as $namespace) {
+                $class = $namespace . ucfirst($endpoint);
+                if (class_exists($class)) {
+                    $this->endPoints[$endpoint] = new $class($this);
+                }
+            }
+            if (!isset($this->endPoints[$endpoint])) {
                 throw new RuntimeException('Endpoint "' . $endpoint . '" does not exist"');
             }
         }
@@ -106,5 +121,14 @@ class WpClient
         );
 
         return $this->httpClient->send($request);
+    }
+
+    /**
+     * Add a new endpoint namespace that is to be searched for endpoints.
+     * @param string $namespace
+     */
+    public function addEndpointNamespace($namespace)
+    {
+        array_unshift($this->endpointNamespaces, $namespace);
     }
 }


### PR DESCRIPTION
Adds possibility to define multiple locations (namespaces) where `WpClient` can look after endpoints.
This feature is useful where custom, domain-specific endpoints are used.

How to use:

Your new endpoint (notice the namespace):
```
namespace Your\Special\Endpoint;

class Examples extends AbstractWpEndpoint
{
...
}
```

And where it is added to WpClient:
```
$client = new WpClient(...);
$client->addEndpointNamespace('Your\Special\Endpoint\\');
$client->examples()->get(1);
```
