### PR TITLE
Return total number of records and pages

### DIFF
--- a/src/Endpoint/AbstractWpEndpoint.php
+++ b/src/Endpoint/AbstractWpEndpoint.php
@@ -45,7 +45,14 @@ abstract class AbstractWpEndpoint
 
         if ($response->hasHeader('Content-Type')
             && substr($response->getHeader('Content-Type')[0], 0, 16) === 'application/json') {
-            return json_decode($response->getBody()->getContents(), true);
+            $result = json_decode($response->getBody()->getContents(), true);
+            if($response->hasHeader('X-WP-Total')){
+                $result['wp_total'] = $response->getHeader('X-WP-Total')[0];
+            }
+            if($response->hasHeader('X-WP-TotalPages')){
+                $result['wp_total_pages'] = $response->getHeader('X-WP-TotalPages')[0];
+            }
+            return $result;
         }
 
         throw new RuntimeException('Unexpected response');


### PR DESCRIPTION
To determine how many pages of data are available, the API returns two header fields with every paginated response:
**X-WP-Total**: the total number of records in the collection
**X-WP-TotalPages**: the total number of pages encompassing all available records
By inspecting these header fields you can determine how much more data is available within the API.

Just added two keys in resulting array:
**wp_total** -> X-WP-Total
**wp_total_pages** -> X-WP-TotalPages

